### PR TITLE
feat: show last selected instance on top

### DIFF
--- a/src/Types/index.d.ts
+++ b/src/Types/index.d.ts
@@ -1,0 +1,6 @@
+type SingleAvailableInstaceType = {
+  value: string
+  name: string
+}
+
+export type AvailableInstancesTypes = SingleAvailableInstaceType[]

--- a/src/Types/index.d.ts
+++ b/src/Types/index.d.ts
@@ -1,6 +1,0 @@
-type SingleAvailableInstaceType = {
-  value: string
-  name: string
-}
-
-export type AvailableInstancesTypes = SingleAvailableInstaceType[]

--- a/src/Types/index.ts
+++ b/src/Types/index.ts
@@ -1,0 +1,4 @@
+export type AvailableInstaceType = {
+  value: string
+  name: string
+}

--- a/src/commands/aws/ec2.ts
+++ b/src/commands/aws/ec2.ts
@@ -10,7 +10,7 @@ import { HckreContext } from '../../api/context'
 import { AWS_REGIONS_MAP, SUPPORTED_AWS_PROFILES, SUPPORTED_AWS_PROFILE_CHOICES } from '../../constants'
 import { compareObjects } from '../../utils'
 import { findInstances } from '../../utils/aws'
-import { AvailableInstancesTypes } from '../../Types'
+import { AvailableInstaceType } from '../../Types'
 
 export default class EC2 extends Command {
   static description = 'login to ec2'
@@ -77,7 +77,7 @@ export default class EC2 extends Command {
     }
 
     if (!ctx.AWSInstance) {
-      let availableInstances: AvailableInstancesTypes = []
+      let availableInstances: AvailableInstaceType[] = []
 
       if (fs.existsSync(instanceCahceListPath)) {
         cli.action.start(`${chalk.green('?')} ${chalk.bold('Fetching targets from cache')}`)


### PR DESCRIPTION
Changes inside?
1. Show the last selected instances names on the top so that developers don't need to search instance names again and again.
2. Delete the last instance cache history with `-r` or after 24hrs flag.